### PR TITLE
Use raw content URL for logo

### DIFF
--- a/catsurvey.xml
+++ b/catsurvey.xml
@@ -2,7 +2,7 @@
    <name>Catsurvey</name>
    <key>catsurvey</key>
    <state>stable</state>
-   <logo>https://github.com/Probesys/glpi-plugins-catsurvey/blob/main/pics/logo.png</logo>
+   <logo>https://raw.githubusercontent.com/Probesys/glpi-plugins-catsurvey/main/pics/logo.png</logo>
    <description>
       <short>
         <fr>Ce plugin permet de créer des enquêtes de satisfaction selon les catégories ITIL</fr>


### PR DESCRIPTION
Use the raw content URL for the logo to point directly to the image rather than the GitHub HTML page for the image.